### PR TITLE
ACM-34944: fix CPE label version for MCE 5.0 branch

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -25,7 +25,7 @@ LABEL org.label-schema.schema-version="1.0"
 
 # Bundle metadata
 LABEL name="multicluster-engine/cloudevents-conductor-rhel9"
-LABEL cpe="cpe:/a:redhat:multicluster_engine:2.17::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_engine:5.0::el9"
 LABEL summary="multicluster cloudevents conductor"
 LABEL io.openshift.expose-services=""
 LABEL io.openshift.tags="data,images"


### PR DESCRIPTION
## Summary

Fixes the Konflux `check-labels` task failure for the `cloudevents-conductor-mce-50` component:

```
Error: Component 'cloudevents-conductor-mce-50' 'cpe' label ('cpe:/a:redhat:multicluster_engine:2.17::el9') does not match the single required CPE value from the data file ('cpe:/a:redhat:multicluster_engine:5.0::el9').
```

## Root Cause

`backplane-5.0` was created from `backplane-2.17` and inherited `Dockerfile.rhtap` unchanged, so the `cpe` LABEL still referenced `multicluster_engine:2.17` instead of `5.0`. Switching the Tekton pipeline to `common.yaml` (done previously) surfaced the mismatch by validating labels against the Konflux component data file, but the underlying Dockerfile label was never corrected.

## Change

`Dockerfile.rhtap`:
```diff
-LABEL cpe="cpe:/a:redhat:multicluster_engine:2.17::el9"
+LABEL cpe="cpe:/a:redhat:multicluster_engine:5.0::el9"
```

Note: `backplane-5.1` is fast-forwarded from `backplane-5.0`, so this fix will propagate there as well.

Jira: https://redhat.atlassian.net/browse/ACM-34944